### PR TITLE
add LOCALE command

### DIFF
--- a/duckyinpython.py
+++ b/duckyinpython.py
@@ -37,6 +37,20 @@ duckyCommands = {
     'F12': Keycode.F12,
 }
 
+def loadLocale(locale):
+    global KeyboardLayout, Keycode, layout
+    if(locale.lower() == "us"):
+        moduleKeyboardLayout = __import__("adafruit_hid.keyboard_layout_us", globals(), locals(), ["KeyboardLayoutUS"])
+        moduleKeycode = __import__("adafruit_hid.keycode", globals(), locals(), ["Keycode"])
+        KeyboardLayout = moduleKeyboardLayout.KeyboardLayoutUS
+        Keycode = moduleKeycode.Keycode
+    else:
+        moduleKeyboardLayout = __import__("keyboard_layout_win_" + locale.lower(), globals(), locals(), ["KeyboardLayout"])
+        moduleKeycode = __import__("keycode_win_" + locale.lower(), globals(), locals(), ["Keycode"])
+        KeyboardLayout = moduleKeyboardLayout.KeyboardLayout
+        Keycode = moduleKeycode.Keycode
+    layout = KeyboardLayout(kbd)
+
 def convertLine(line):
     newline = []
     print(line)
@@ -77,6 +91,8 @@ def parseLine(line):
         defaultDelay = int(line[14:]) * 10
     elif(line[0:12] == "DEFAULTDELAY"):
         defaultDelay = int(line[13:]) * 10
+    elif(line[0:6] == "LOCALE"):
+        loadLocale(line[7:])
     else:
         newScriptLine = convertLine(line)
         runScriptLine(newScriptLine)


### PR DESCRIPTION
added new command `LOCALE` command to dynamically switch keyboard layout. allows defining your keyboard layouts in the payload rather than having to modify `duckyinpython.py` or `code.py`. best used as first line in the payload to fix the locale.

could be useful to switch keyboard layouts at runtime in between other commands. think rare cases where applications use different keyboard layouts.

syntax:
`LOCALE DE` will load keyboard_layout_win_de and keycode_win_de
`LOCALE SW` will load keyboard_layout_win_sw and keycode_win_sw
`LOCALE FR` will load keyboard_layout_win_fr and keycode_win_fr
...

stole the idea from @spacehuhn and his awesome [WifiDuck](https://github.com/SpacehuhnTech/WiFiDuck#scripting)