### PR TITLE
fix: defaultdelay not set correctly

### DIFF
--- a/duckyinpython.py
+++ b/duckyinpython.py
@@ -66,6 +66,7 @@ def sendString(line):
     layout.write(line)
 
 def parseLine(line):
+    global defaultDelay
     if(line[0:3] == "REM"):
         # ignore ducky script comments
         pass


### PR DESCRIPTION
`defaultDelay` wasn't set correctly due to incorrect scope. the previous code wasn't referencing the global `defaultDelay` variable.