### PR TITLE
Change button monitoring and LED to async tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,17 @@ Install and have your USB Rubber Ducky working in less than 5 minutes.
 
 4. Download `adafruit-circuitpython-bundle-7.x-mpy-YYYYMMDD.zip` [here](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest) and extract it outside the device.
 
-5. Navigate to `lib` in the recently extracted folder and copy `adafruit_hid` to the `lib` folder in your Raspberry Pi Pico.
+5. Navigate to `lib` in the recently extracted folder and copy `adafruit_hid` to the `lib` folder on your Raspberry Pi Pico.
 
-6. Copy `adafruit_debouncer.mpy` and `adafruit_ticks.mpy` to the `lib` folder in your Raspberry Pi Pico.
+6. Copy `adafruit_debouncer.mpy` and `adafruit_ticks.mpy` to the `lib` folder on your Raspberry Pi Pico.
 
-7. Click [here](https://raw.githubusercontent.com/dbisu/pico-ducky/main/duckyinpython.py), press CTRL + S and save the file as `code.py` in the root of the Raspberry Pi Pico, overwriting the previous file.
+7. Copy `asyncio` to the `lib` folder on your Pico.
 
-8. Find a script [here](https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Payloads) or [create your own one using Ducky Script](https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript) and save it as `payload.dd` in the Pico.
+8. Click [here](https://raw.githubusercontent.com/dbisu/pico-ducky/main/duckyinpython.py), press CTRL + S and save the file as `code.py` in the root of the Raspberry Pi Pico, overwriting the previous file.
 
-9. Be careful, if your device isn't in [setup mode](#setup-mode), the device will reboot and after half a second, the script will run.
+9. Find a script [here](https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Payloads) or [create your own one using Ducky Script](https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript) and save it as `payload.dd` in the Pico.
+
+10. Be careful, if your device isn't in [setup mode](#setup-mode), the device will reboot and after half a second, the script will run.
 
 ### Setup mode
 

--- a/duckyinpython.py
+++ b/duckyinpython.py
@@ -22,6 +22,7 @@ from digitalio import DigitalInOut, Pull
 from adafruit_debouncer import Debouncer
 from board import *
 import pwmio
+import asyncio
 
 led = pwmio.PWMOut(LED, frequency=5000, duty_cycle=0)
 
@@ -135,6 +136,16 @@ button1_pin = DigitalInOut(GP22) # defaults to input
 button1_pin.pull = Pull.UP      # turn on internal pull-up resistor
 button1 =  Debouncer(button1_pin)
 
+#init payload selection switch
+payload1Pin = digitalio.DigitalInOut(GP4)
+payload1Pin.switch_to_input(pull=digitalio.Pull.UP)
+payload2Pin = digitalio.DigitalInOut(GP5)
+payload2Pin.switch_to_input(pull=digitalio.Pull.UP)
+payload3Pin = digitalio.DigitalInOut(GP10)
+payload3Pin.switch_to_input(pull=digitalio.Pull.UP)
+payload4Pin = digitalio.DigitalInOut(GP11)
+payload4Pin.switch_to_input(pull=digitalio.Pull.UP)
+
 def getProgrammingStatus():
     # check GP0 for setup mode
     # see setup mode for instructions
@@ -168,23 +179,16 @@ def runScript(file):
         print("Unable to open file ", file)
 
 def selectPayload():
+    global payload1Pin, payload2Pin, payload3Pin, payload4Pin
     payload = "payload.dd"
     # check switch status
     # payload1 = GPIO4 to GND
     # payload2 = GPIO5 to GND
     # payload3 = GPIO10 to GND
     # payload4 = GPIO11 to GND
-    payload1Pin = digitalio.DigitalInOut(GP4)
-    payload1Pin.switch_to_input(pull=digitalio.Pull.UP)
     payload1State = not payload1Pin.value
-    payload2Pin = digitalio.DigitalInOut(GP5)
-    payload2Pin.switch_to_input(pull=digitalio.Pull.UP)
     payload2State = not payload2Pin.value
-    payload3Pin = digitalio.DigitalInOut(GP10)
-    payload3Pin.switch_to_input(pull=digitalio.Pull.UP)
     payload3State = not payload3Pin.value
-    payload4Pin = digitalio.DigitalInOut(GP11)
-    payload4Pin.switch_to_input(pull=digitalio.Pull.UP)
     payload4State = not payload4Pin.value
 
 
@@ -208,6 +212,63 @@ def selectPayload():
 
     return payload
 
+
+async def blink_pico_led(led):
+    print("starting blink_pico_led")
+    led_state = False
+    while True:
+        if led_state:
+            #led_pwm_up(led)
+            print("led up")
+            for i in range(100):
+                # PWM LED up and down
+                if i < 50:
+                    led.duty_cycle = int(i * 2 * 65535 / 100)  # Up
+                await asyncio.sleep(0.01)
+            led_state = False
+        else:
+            #led_pwm_down(led)
+            print("led down")
+            for i in range(100):
+                # PWM LED up and down
+                if i >= 50:
+                    led.duty_cycle = 65535 - int((i - 50) * 2 * 65535 / 100)  # Down
+                await asyncio.sleep(0.01)
+            led_state = True
+        await asyncio.sleep(0)
+
+async def monitor_buttons(button1):
+    global inBlinkeyMode, inMenu, enableRandomBeep, enableSirenMode,pixel
+    print("starting monitor_buttons")
+    button1Down = False
+    while True:
+        button1.update()
+
+        button1Pushed = button1.fell
+        button1Released = button1.rose
+        button1Held = not button1.value
+
+        if(button1Pushed):
+            print("Button 1 pushed")
+            button1Down = True
+        if(button1Released):
+            print("Button 1 released")
+            if(button1Down):
+                print("push and released")
+
+        if(button1Released):
+            if(button1Down):
+                # Run selected payload
+                payload = selectPayload()
+                print("Running ", payload)
+                runScript(payload)
+                print("Done")
+            button1Down = False
+
+        await asyncio.sleep(0)
+
+
+
 progStatus = False
 progStatus = getProgrammingStatus()
 
@@ -222,16 +283,11 @@ else:
     print("Update your payload")
 
 led_state = False
-while True:
-    button1.update()
-    button1Pushed = button1.fell
-    if(button1Pushed):
-        runScript(payload)
-        button1Pushed = False
 
-    if led_state:
-        led_pwm_up(led)
-        led_state = False
-    else:
-        led_pwm_down(led)
-        led_state = True
+async def main_loop():
+    global led,button1
+    pico_led_task = asyncio.create_task(blink_pico_led(led))
+    button_task = asyncio.create_task(monitor_buttons(button1))
+    await asyncio.gather(pico_led_task, button_task)
+
+asyncio.run(main_loop())


### PR DESCRIPTION
Moves the button monitoring and LED function to their own tasks to allow running concurrently.
The LED will maintain current brightness while a payload is running.
Please note that the asyncio library will need to be added to the `lib` folder on the Pico.