### PR TITLE
Update links for payloads and DuckyScript reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install and have your USB Rubber Ducky working in less than 5 minutes.
 10. Copy `duckyinpython.py` as `code.py` in the root of the Raspberry Pi Pico, overwriting the previous file.  
      Linux: `cp duckyinpython.py </path/to/pico/code.py`
 
-11. Find a script [here](https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Payloads) or [create your own one using Ducky Script](https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript) and save it as `payload.dd` in the Pico.
+11. Find a script [here](https://github.com/hak5/usbrubberducky-payloads) or [create your own one using Ducky Script](https://docs.hak5.org/hak5-usb-rubber-ducky/duckyscript-tm-quick-reference) and save it as `payload.dd` in the Pico.
 
 12. Be careful, if your device isn't in [setup mode](#setup-mode), the device will reboot and after half a second, the script will run.
 


### PR DESCRIPTION
Just updated the links for payloads and DuckyScript to the current location, relates to #115 