### PR TITLE
Update a typo in duckyinpython.py

### DIFF
--- a/duckyinpython.py
+++ b/duckyinpython.py
@@ -105,7 +105,7 @@ def parseLine(line, script_lines):
             led.value = True
     elif(line[0:21] == "WAIT_FOR_BUTTON_PRESS"):
         button_pressed = False
-        # NOTE: we don't use assincio in this case because we want to block code execution
+        # NOTE: we don't use asyncio in this case because we want to block code execution
         while not button_pressed:
             button1.update()
 

--- a/duckyinpython.py
+++ b/duckyinpython.py
@@ -12,6 +12,7 @@ from board import *
 import pwmio
 import asyncio
 import usb_hid
+from absolute_mouse import Mouse
 from adafruit_hid.keyboard import Keyboard
 
 # comment out these lines for non_US keyboards

--- a/duckyinpython.py
+++ b/duckyinpython.py
@@ -52,7 +52,7 @@ duckyCommands = {
 variables = {}
 functions = {}
 
-def convertLine(line):
+def convertLine(line): # change to add mouse support
     newline = []
     # print(line)
     # loop on each key - the filter removes empty values
@@ -78,6 +78,7 @@ def runScriptLine(line):
     for k in line:
         kbd.press(k)
     kbd.release_all()
+    
 def sendString(line):
     layout.write(line)
 


### PR DESCRIPTION
In line 108 of duckyinpython.py, there was a typo: "assincio" instead of the correct "asyncio."