### PR TITLE
Fix syntax error in await runScript call

### DIFF
--- a/code.py
+++ b/code.py
@@ -59,7 +59,7 @@ async def run_payload_on_startup():
             payload = selectPayload()
             await asyncio.sleep(0.1)
             print("Running")
-            awaitrunScript(payload)
+            await runScript(payload)
     else:
         print("Done")
 


### PR DESCRIPTION
There's a syntax error on line 62, it is missing a space after the await function and isn't separating the runScript call correctly.